### PR TITLE
Add public landing site with 6 pages

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,79 @@
+name: Deploy Frontend to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/deploy-frontend.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build
+        working-directory: frontend
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=workmate
+          workingDirectory: frontend
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `🚀 **Cloudflare Pages Preview**\n\nDeployed to: ${process.env.DEPLOYMENT_URL}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes('Cloudflare Pages Preview'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,5 +1,4 @@
 import { Routes, Route } from "react-router-dom";
-import { LoginPage } from "./pages/LoginPage";
 import { ChatPage } from "./pages/ChatPage";
 import { AdminPage } from "./pages/AdminPage";
 import { SettingsPage } from "./pages/SettingsPage";
@@ -9,12 +8,11 @@ import { Sidebar } from "./components/Sidebar";
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route
-        path="/admin"
-        element={
-          <ProtectedRoute>
+    <ProtectedRoute>
+      <Routes>
+        <Route
+          path="admin"
+          element={
             <AdminRoute>
               <div className="flex h-screen overflow-hidden bg-white dark:bg-slate-900">
                 <Sidebar
@@ -25,13 +23,11 @@ export default function App() {
                 <AdminPage />
               </div>
             </AdminRoute>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/settings"
-        element={
-          <ProtectedRoute>
+          }
+        />
+        <Route
+          path="settings"
+          element={
             <div className="flex h-screen overflow-hidden bg-white dark:bg-slate-900">
               <Sidebar
                 activeConversationId={null}
@@ -40,17 +36,10 @@ export default function App() {
               />
               <SettingsPage />
             </div>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/*"
-        element={
-          <ProtectedRoute>
-            <ChatPage />
-          </ProtectedRoute>
-        }
-      />
-    </Routes>
+          }
+        />
+        <Route path="*" element={<ChatPage />} />
+      </Routes>
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/app/components/Sidebar.tsx
+++ b/frontend/src/app/components/Sidebar.tsx
@@ -270,14 +270,14 @@ export function Sidebar({
           <div className="space-y-1.5">
             {workspaces.length === 0 ? (
               <Link
-                to="/settings"
+                to="/app/settings"
                 className="block text-xs text-slate-400 hover:text-purple-500 text-center py-3 transition-colors"
               >
                 Connect a Notion workspace
               </Link>
             ) : (
               workspaces.map((workspace) => (
-                <Link key={workspace.id} to="/settings">
+                <Link key={workspace.id} to="/app/settings">
                 <Card
                   className="p-2.5 hover:bg-white dark:hover:bg-slate-800 transition-colors cursor-pointer border-slate-200 dark:border-slate-700"
                 >
@@ -309,9 +309,9 @@ export function Sidebar({
         {/* Navigation Links */}
         <div className="space-y-1 flex-shrink-0">
           <Link
-            to="/"
+            to="/app"
             className={`flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-              location.pathname === '/'
+              location.pathname === '/app'
                 ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300'
                 : 'text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-800'
             }`}
@@ -320,9 +320,9 @@ export function Sidebar({
             Chat
           </Link>
           <Link
-            to="/settings"
+            to="/app/settings"
             className={`flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-              location.pathname === '/settings'
+              location.pathname === '/app/settings'
                 ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300'
                 : 'text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-800'
             }`}
@@ -332,9 +332,9 @@ export function Sidebar({
           </Link>
           {isAdmin && (
             <Link
-              to="/admin"
+              to="/app/admin"
               className={`flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-                location.pathname === '/admin'
+                location.pathname === '/app/admin'
                   ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300'
                   : 'text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-800'
               }`}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,16 +1,40 @@
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "next-themes";
 import { AuthProvider } from "./app/contexts/AuthContext";
 import { Toaster } from "./app/components/ui/sonner";
-import App from "./app/App.tsx";
+import App from "./app/App";
+import { PublicLayout } from "./public/layouts/PublicLayout";
+import { LandingPage } from "./public/pages/LandingPage";
+import { AboutPage } from "./public/pages/AboutPage";
+import { PricingPage } from "./public/pages/PricingPage";
+import { DocsPage } from "./public/pages/DocsPage";
+import { DemoPage } from "./public/pages/DemoPage";
+import { ContactPage } from "./public/pages/ContactPage";
+import { LoginPage } from "./app/pages/LoginPage";
 import "./styles/index.css";
 
 createRoot(document.getElementById("root")!).render(
   <BrowserRouter>
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <AuthProvider>
-        <App />
+        <Routes>
+          {/* Public marketing site */}
+          <Route element={<PublicLayout />}>
+            <Route index element={<LandingPage />} />
+            <Route path="about" element={<AboutPage />} />
+            <Route path="pricing" element={<PricingPage />} />
+            <Route path="docs" element={<DocsPage />} />
+            <Route path="demo" element={<DemoPage />} />
+            <Route path="contact" element={<ContactPage />} />
+          </Route>
+
+          {/* Auth */}
+          <Route path="login" element={<LoginPage />} />
+
+          {/* Authenticated app */}
+          <Route path="app/*" element={<App />} />
+        </Routes>
         <Toaster position="bottom-right" richColors />
       </AuthProvider>
     </ThemeProvider>

--- a/frontend/src/public/components/ComingSoon.tsx
+++ b/frontend/src/public/components/ComingSoon.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+import type { LucideIcon } from "lucide-react";
+
+interface ComingSoonProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+export function ComingSoon({ icon: Icon, title, description }: ComingSoonProps) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6 text-center">
+      <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-purple-600/[0.08] border border-purple-600/20">
+        <Icon className="h-7 w-7 text-purple-500" />
+      </div>
+      <h1 className="text-2xl font-bold text-white">{title}</h1>
+      <p className="mt-2 text-sm text-white/40">{description}</p>
+      <Link
+        to="/"
+        className="mt-6 text-sm text-purple-500 transition-colors hover:text-purple-400"
+      >
+        &larr; Back to Home
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/public/components/Footer.tsx
+++ b/frontend/src/public/components/Footer.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+
+const footerLinks = [
+  { label: "About", href: "/about" },
+  { label: "Pricing", href: "/pricing" },
+  { label: "Docs", href: "/docs" },
+  { label: "Contact", href: "/contact" },
+  { label: "GitHub", href: "https://github.com/RubyRyn/WorkMate" },
+];
+
+export function Footer() {
+  return (
+    <footer className="border-t border-white/[0.06] px-6 py-8">
+      <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 sm:flex-row">
+        <p className="text-xs text-white/30">
+          &copy; 2026 WorkMate. Built at SFBU.
+        </p>
+        <div className="flex gap-6">
+          {footerLinks.map((link) =>
+            link.href.startsWith("http") ? (
+              <a
+                key={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-white/30 transition-colors hover:text-white/60"
+              >
+                {link.label}
+              </a>
+            ) : (
+              <Link
+                key={link.label}
+                to={link.href}
+                className="text-xs text-white/30 transition-colors hover:text-white/60"
+              >
+                {link.label}
+              </Link>
+            )
+          )}
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/public/components/Navbar.tsx
+++ b/frontend/src/public/components/Navbar.tsx
@@ -1,0 +1,138 @@
+import { useState, useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { Menu, X } from "lucide-react";
+import { useAuth } from "@/app/contexts/AuthContext";
+import { Sheet, SheetContent, SheetTrigger } from "@/app/components/ui/sheet";
+
+const navLinks = [
+  { label: "About", href: "/about" },
+  { label: "Pricing", href: "/pricing" },
+  { label: "Docs", href: "/docs" },
+  { label: "Demo", href: "/demo" },
+  { label: "Contact", href: "/contact" },
+];
+
+export function Navbar() {
+  const { user } = useAuth();
+  const location = useLocation();
+  const [scrolled, setScrolled] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => setScrolled(window.scrollY > 10);
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <nav
+      className={`sticky top-0 z-50 transition-all duration-300 ${
+        scrolled
+          ? "bg-[#0a0a14]/80 backdrop-blur-lg border-b border-white/[0.06]"
+          : "bg-transparent"
+      }`}
+    >
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+        <Link to="/" className="text-lg font-bold text-white">
+          WorkMate
+        </Link>
+
+        <div className="hidden items-center gap-8 md:flex">
+          {navLinks.map((link) => (
+            <Link
+              key={link.href}
+              to={link.href}
+              className={`text-sm transition-colors ${
+                location.pathname === link.href
+                  ? "text-purple-500"
+                  : "text-white/50 hover:text-white/80"
+              }`}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+
+        <div className="hidden items-center gap-3 md:flex">
+          {user ? (
+            <Link
+              to="/app"
+              className="rounded-lg bg-purple-600 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-700"
+            >
+              Go to App
+            </Link>
+          ) : (
+            <>
+              <Link
+                to="/login"
+                className="text-sm text-white/50 transition-colors hover:text-white/80"
+              >
+                Sign In
+              </Link>
+              <Link
+                to="/login"
+                className="rounded-lg bg-purple-600 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-700"
+              >
+                Get Started
+              </Link>
+            </>
+          )}
+        </div>
+
+        <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+          <SheetTrigger asChild className="md:hidden">
+            <button className="text-white/60">
+              <Menu className="h-6 w-6" />
+            </button>
+          </SheetTrigger>
+          <SheetContent side="right" className="bg-[#0a0a14] border-white/[0.06] w-64">
+            <div className="flex flex-col gap-4 pt-8">
+              {navLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  to={link.href}
+                  onClick={() => setMobileOpen(false)}
+                  className={`text-sm ${
+                    location.pathname === link.href
+                      ? "text-purple-500"
+                      : "text-white/50"
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              ))}
+              <div className="mt-4 border-t border-white/[0.06] pt-4">
+                {user ? (
+                  <Link
+                    to="/app"
+                    onClick={() => setMobileOpen(false)}
+                    className="block rounded-lg bg-purple-600 px-4 py-2 text-center text-sm font-medium text-white"
+                  >
+                    Go to App
+                  </Link>
+                ) : (
+                  <>
+                    <Link
+                      to="/login"
+                      onClick={() => setMobileOpen(false)}
+                      className="block text-sm text-white/50 mb-3"
+                    >
+                      Sign In
+                    </Link>
+                    <Link
+                      to="/login"
+                      onClick={() => setMobileOpen(false)}
+                      className="block rounded-lg bg-purple-600 px-4 py-2 text-center text-sm font-medium text-white"
+                    >
+                      Get Started
+                    </Link>
+                  </>
+                )}
+              </div>
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/public/components/hero/ChatPreview.tsx
+++ b/frontend/src/public/components/hero/ChatPreview.tsx
@@ -1,0 +1,36 @@
+import { motion } from "motion/react";
+
+export function ChatPreview() {
+  return (
+    <div className="mx-auto mt-8 max-w-md rounded-xl border border-white/[0.08] bg-white/[0.03] p-5 text-left">
+      <p className="text-sm text-white/40">
+        <span className="mr-1">{"\u{1F4AC}"}</span>
+        <span className="text-white/60">
+          What did we decide about the pricing model?
+        </span>
+      </p>
+
+      <div className="my-3 h-px bg-white/[0.05]" />
+
+      <div className="text-sm leading-relaxed text-white/50">
+        <span className="font-medium text-purple-500">WorkMate</span> — Based
+        on your Q3 Strategy Doc and Product Roadmap, the team agreed on a
+        freemium model with...
+        <motion.span
+          className="ml-0.5 inline-block h-3.5 w-1.5 rounded-sm bg-purple-500 align-middle"
+          animate={{ opacity: [1, 0] }}
+          transition={{ duration: 0.8, repeat: Infinity }}
+        />
+      </div>
+
+      <div className="mt-3 flex gap-2">
+        <span className="rounded bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-500">
+          2 sources cited
+        </span>
+        <span className="rounded bg-purple-500/10 px-2 py-0.5 text-[10px] text-purple-500">
+          High confidence
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/public/components/hero/FloatingDocs.tsx
+++ b/frontend/src/public/components/hero/FloatingDocs.tsx
@@ -1,0 +1,30 @@
+import { motion } from "motion/react";
+
+const docs = [
+  { label: "Q3 Strategy", emoji: "\u{1F4C4}", x: "5%", y: "8%", rotate: -2 },
+  { label: "Sprint Board", emoji: "\u{1F4CA}", x: "75%", y: "12%", rotate: 1.5 },
+  { label: "Meeting Notes", emoji: "\u{1F4DD}", x: "8%", y: "70%", rotate: 1 },
+  { label: "Roadmap", emoji: "\u{1F5C2}\uFE0F", x: "72%", y: "75%", rotate: -1 },
+];
+
+export function FloatingDocs() {
+  return (
+    <>
+      {docs.map((doc, i) => (
+        <motion.div
+          key={doc.label}
+          className="absolute hidden rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 py-2 text-xs text-white/25 backdrop-blur-sm md:block"
+          style={{ left: doc.x, top: doc.y, rotate: doc.rotate }}
+          animate={{ y: [0, -8, 0] }}
+          transition={{
+            duration: 4 + i * 0.5,
+            repeat: Infinity,
+            ease: "easeInOut",
+          }}
+        >
+          <span className="opacity-50">{doc.emoji}</span> {doc.label}
+        </motion.div>
+      ))}
+    </>
+  );
+}

--- a/frontend/src/public/components/hero/HeroSection.tsx
+++ b/frontend/src/public/components/hero/HeroSection.tsx
@@ -1,0 +1,45 @@
+import { Link } from "react-router-dom";
+import { FloatingDocs } from "./FloatingDocs";
+import { ChatPreview } from "./ChatPreview";
+
+export function HeroSection() {
+  return (
+    <section className="relative overflow-hidden px-6 pb-16 pt-20 text-center md:pt-28 md:pb-24">
+      <div className="pointer-events-none absolute left-1/2 top-1/2 h-[500px] w-[600px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[radial-gradient(ellipse,rgba(124,58,237,0.07)_0%,transparent_70%)]" />
+
+      <FloatingDocs />
+
+      <div className="relative z-10 mx-auto max-w-xl">
+        <p className="mb-4 text-[10px] font-medium uppercase tracking-[3px] text-purple-500">
+          AI-Powered Knowledge Assistant
+        </p>
+        <h1 className="text-3xl font-bold leading-tight tracking-tight text-white md:text-5xl">
+          Your Notion workspace,
+          <br />
+          <span className="text-purple-500">answered instantly.</span>
+        </h1>
+        <p className="mt-4 text-sm leading-relaxed text-white/40 md:text-base">
+          Ask questions across all your documents. Get sourced answers in
+          real-time.
+        </p>
+
+        <ChatPreview />
+
+        <div className="mt-8 flex items-center justify-center gap-3">
+          <Link
+            to="/login"
+            className="rounded-lg bg-purple-600 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-purple-700"
+          >
+            Get Started Free
+          </Link>
+          <a
+            href="#how-it-works"
+            className="rounded-lg border border-white/10 px-6 py-3 text-sm text-white/50 transition-colors hover:border-white/20 hover:text-white/70"
+          >
+            See How It Works
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/public/layouts/PublicLayout.tsx
+++ b/frontend/src/public/layouts/PublicLayout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from "react-router-dom";
+import { Navbar } from "../components/Navbar";
+import { Footer } from "../components/Footer";
+
+export function PublicLayout() {
+  return (
+    <div className="min-h-screen bg-[#0a0a14] text-white">
+      <Navbar />
+      <main>
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/public/pages/AboutPage.tsx
+++ b/frontend/src/public/pages/AboutPage.tsx
@@ -1,0 +1,180 @@
+import { motion } from "motion/react";
+import { Github, Linkedin } from "lucide-react";
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 24 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-60px" },
+  transition: { duration: 0.5 },
+};
+
+const team = [
+  {
+    name: "Emmanuel Owusu",
+    initials: "EO",
+    role: "DevOps Engineer",
+    bio: "Cloud infrastructure, CI/CD pipelines, Docker containerization",
+    github: "#",
+    linkedin: "#",
+  },
+  {
+    name: "Jubaida Tasnim",
+    initials: "JT",
+    role: "Full Stack Developer",
+    bio: "React UI, FastAPI endpoints, real-time streaming, source citations",
+    github: "#",
+    linkedin: "#",
+  },
+  {
+    name: "Rutvik Katkoriya",
+    initials: "RK",
+    role: "Data Engineer",
+    bio: "ETL pipeline, Notion ingestion, retrieval system, metadata engineering",
+    github: "#",
+    linkedin: "#",
+  },
+  {
+    name: "Nila Ko",
+    initials: "NK",
+    role: "AI Engineer",
+    bio: "RAG pipeline, prompt engineering, embeddings, evaluation",
+    github: "#",
+    linkedin: "#",
+  },
+];
+
+const techGrid = [
+  {
+    label: "Frontend",
+    color: "text-purple-500",
+    items: ["React + TypeScript", "Vite", "Tailwind CSS + shadcn/ui", "Motion"],
+  },
+  {
+    label: "Backend",
+    color: "text-purple-500",
+    items: ["FastAPI (Python)", "Google OAuth 2.0", "SSE Streaming", "LangChain"],
+  },
+  {
+    label: "AI & Data",
+    color: "text-purple-500",
+    items: ["Gemini 2.5 Flash", "ChromaDB + BM25", "Voyage AI Re-ranker", "PostgreSQL"],
+  },
+  { label: "Cloudflare", color: "text-amber-500", items: ["Pages (Frontend CDN)"] },
+  { label: "AWS", color: "text-blue-500", items: ["EKS + Secrets Manager"] },
+  {
+    label: "IBM LinuxONE",
+    color: "text-emerald-500",
+    items: ["ChromaDB + PostgreSQL"],
+  },
+];
+
+export function AboutPage() {
+  return (
+    <>
+      <section className="relative px-6 pb-12 pt-20 text-center md:pt-28">
+        <div className="pointer-events-none absolute left-1/2 top-1/2 h-[300px] w-[500px] -translate-x-1/2 -translate-y-1/2 bg-[radial-gradient(ellipse,rgba(124,58,237,0.05)_0%,transparent_70%)]" />
+        <div className="relative z-10 mx-auto max-w-xl">
+          <p className="mb-4 text-[10px] uppercase tracking-[3px] text-purple-500">
+            About WorkMate
+          </p>
+          <h1 className="text-2xl font-bold leading-snug text-white md:text-3xl">
+            We believe your team&apos;s knowledge shouldn&apos;t be buried in
+            documents.
+          </h1>
+          <p className="mt-4 text-sm leading-relaxed text-white/40">
+            WorkMate was born from a simple frustration: teams store critical
+            knowledge in Notion, but finding specific answers means digging
+            through pages manually. We built an AI assistant that retrieves,
+            reasons over, and cites your workspace documents — so your team can
+            focus on decisions, not searching.
+          </p>
+        </div>
+      </section>
+
+      <div className="mx-6 h-px bg-gradient-to-r from-transparent via-white/5 to-transparent" />
+
+      <section className="px-6 py-16">
+        <motion.div className="mb-10 text-center" {...fadeInUp}>
+          <p className="mb-3 text-[10px] uppercase tracking-[3px] text-purple-500">
+            The Team
+          </p>
+          <h2 className="text-xl font-bold text-white md:text-2xl">
+            Built by engineers who care about knowledge access
+          </h2>
+          <p className="mt-2 text-xs text-white/35">
+            San Francisco Bay University — CS Capstone, Spring 2026
+          </p>
+        </motion.div>
+        <div className="mx-auto grid max-w-4xl gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {team.map((m, i) => (
+            <motion.div
+              key={m.name}
+              className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-6 text-center"
+              {...fadeInUp}
+              transition={{ duration: 0.5, delay: i * 0.1 }}
+            >
+              <div className="mx-auto mb-4 flex h-[72px] w-[72px] items-center justify-center rounded-full border border-purple-600/20 bg-purple-600/10 text-xl text-white/30">
+                {m.initials}
+              </div>
+              <h3 className="text-sm font-semibold text-white">{m.name}</h3>
+              <p className="mt-1 text-[11px] text-purple-500">{m.role}</p>
+              <p className="mt-2 text-[11px] leading-relaxed text-white/35">
+                {m.bio}
+              </p>
+              <div className="mt-3 flex justify-center gap-3">
+                <a
+                  href={m.github}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-white/30 transition-colors hover:text-white/60"
+                >
+                  <Github className="h-3.5 w-3.5" />
+                </a>
+                <a
+                  href={m.linkedin}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-white/30 transition-colors hover:text-white/60"
+                >
+                  <Linkedin className="h-3.5 w-3.5" />
+                </a>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+
+      <div className="mx-6 h-px bg-gradient-to-r from-transparent via-white/5 to-transparent" />
+
+      <section className="px-6 py-16">
+        <motion.div className="mb-10 text-center" {...fadeInUp}>
+          <p className="mb-3 text-[10px] uppercase tracking-[3px] text-purple-500">
+            Tech Stack
+          </p>
+          <h2 className="text-xl font-bold text-white md:text-2xl">
+            What powers WorkMate
+          </h2>
+        </motion.div>
+        <div className="mx-auto grid max-w-3xl gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {techGrid.map((g, i) => (
+            <motion.div
+              key={g.label}
+              className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-5"
+              {...fadeInUp}
+              transition={{ duration: 0.5, delay: i * 0.08 }}
+            >
+              <p className={`mb-2 text-[10px] uppercase tracking-widest ${g.color}`}>
+                {g.label}
+              </p>
+              <div className="text-xs leading-[2] text-white/50">
+                {g.items.map((item) => (
+                  <div key={item}>{item}</div>
+                ))}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/frontend/src/public/pages/ContactPage.tsx
+++ b/frontend/src/public/pages/ContactPage.tsx
@@ -1,0 +1,12 @@
+import { Mail } from "lucide-react";
+import { ComingSoon } from "../components/ComingSoon";
+
+export function ContactPage() {
+  return (
+    <ComingSoon
+      icon={Mail}
+      title="Contact & Legal"
+      description="Need to reach us? This page is coming soon."
+    />
+  );
+}

--- a/frontend/src/public/pages/DemoPage.tsx
+++ b/frontend/src/public/pages/DemoPage.tsx
@@ -1,0 +1,12 @@
+import { Play } from "lucide-react";
+import { ComingSoon } from "../components/ComingSoon";
+
+export function DemoPage() {
+  return (
+    <ComingSoon
+      icon={Play}
+      title="Demo"
+      description="An interactive walkthrough is on the way."
+    />
+  );
+}

--- a/frontend/src/public/pages/DocsPage.tsx
+++ b/frontend/src/public/pages/DocsPage.tsx
@@ -1,0 +1,135 @@
+import { motion } from "motion/react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/app/components/ui/accordion";
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 24 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-60px" },
+  transition: { duration: 0.5 },
+};
+
+const gettingStarted = [
+  {
+    title: "Sign in with Google",
+    desc: 'Click "Get Started" and authenticate with your Google account. No passwords to remember.',
+  },
+  {
+    title: "Connect your Notion workspace",
+    desc: "Go to Settings and click \u201CConnect Notion.\u201D You\u2019ll authorize WorkMate to read your workspace pages and databases. Documents are automatically ingested and indexed.",
+  },
+  {
+    title: "Start asking questions",
+    desc: "Type a question in the chat. WorkMate searches your connected documents using hybrid search, then streams an answer with source citations and confidence scores.",
+  },
+  {
+    title: "Upload additional files (optional)",
+    desc: "Drag and drop PDFs, text files, or markdown into the chat. They\u2019ll be chunked, embedded, and searchable alongside your Notion content.",
+  },
+];
+
+const faqItems = [
+  {
+    q: "What data does WorkMate access from my Notion?",
+    a: "WorkMate reads pages, databases, and blocks from workspaces you explicitly authorize via OAuth. We never access workspaces you haven\u2019t connected. All tokens are encrypted at rest using Fernet encryption.",
+  },
+  {
+    q: "Can other users see my documents?",
+    a: "No. WorkMate is multi-tenant with workspace isolation. Your RAG queries are scoped to your connected workspace IDs only. Other users cannot access or search your documents.",
+  },
+  {
+    q: "What file types can I upload?",
+    a: "PDF, plain text (.txt), and Markdown (.md) files. Uploaded files are chunked using LangChain and embedded alongside your Notion content for unified search.",
+  },
+  {
+    q: "How accurate are the answers?",
+    a: "WorkMate uses a hybrid search pipeline (BM25 + vector similarity) with Voyage AI re-ranking to find the most relevant chunks. Every answer includes confidence scores and source citations so you can verify. The LLM runs at temperature 0.0 for deterministic, consistent outputs.",
+  },
+  {
+    q: "How do I sync new Notion changes?",
+    a: 'Go to Settings \u2192 Connected Workspaces and click the "Sync" button next to your workspace. WorkMate will re-ingest all pages and update the vector database.',
+  },
+  {
+    q: "Is my data secure?",
+    a: "Yes. Notion OAuth tokens are encrypted with Fernet. API keys are stored in AWS Secrets Manager. All traffic uses HTTPS. The database runs on IBM LinuxONE with workspace-scoped access controls.",
+  },
+];
+
+export function DocsPage() {
+  return (
+    <>
+      <section className="px-6 pb-8 pt-20 text-center md:pt-28">
+        <p className="mb-4 text-[10px] uppercase tracking-[3px] text-purple-500">
+          Documentation
+        </p>
+        <h1 className="text-2xl font-bold text-white md:text-3xl">
+          Get up and running
+        </h1>
+        <p className="mt-3 text-sm text-white/40">
+          Everything you need to connect your workspace and start asking
+          questions.
+        </p>
+      </section>
+
+      <section className="px-6 pb-12">
+        <div className="mx-auto max-w-2xl">
+          <p className="mb-6 text-[10px] uppercase tracking-widest text-purple-500">
+            Getting Started
+          </p>
+          <div className="space-y-6">
+            {gettingStarted.map((step, i) => (
+              <motion.div
+                key={step.title}
+                className="flex gap-4"
+                {...fadeInUp}
+                transition={{ duration: 0.5, delay: i * 0.1 }}
+              >
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-purple-600/25 bg-purple-600/10 text-sm font-semibold text-purple-500">
+                  {i + 1}
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold text-white">
+                    {step.title}
+                  </h3>
+                  <p className="mt-1 text-xs leading-relaxed text-white/40">
+                    {step.desc}
+                  </p>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <div className="mx-6 h-px bg-gradient-to-r from-transparent via-white/5 to-transparent" />
+
+      <section className="px-6 py-12">
+        <div className="mx-auto max-w-2xl">
+          <p className="mb-6 text-[10px] uppercase tracking-widest text-purple-500">
+            Frequently Asked Questions
+          </p>
+          <Accordion type="single" collapsible className="space-y-2">
+            {faqItems.map((item, i) => (
+              <AccordionItem
+                key={i}
+                value={`faq-${i}`}
+                className="rounded-lg border border-white/[0.08] px-5 data-[state=open]:border-white/[0.12]"
+              >
+                <AccordionTrigger className="py-4 text-left text-sm font-medium text-white/70 hover:text-white hover:no-underline">
+                  {item.q}
+                </AccordionTrigger>
+                <AccordionContent className="pb-4 text-xs leading-relaxed text-white/40">
+                  {item.a}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/frontend/src/public/pages/LandingPage.tsx
+++ b/frontend/src/public/pages/LandingPage.tsx
@@ -1,0 +1,185 @@
+import { Link } from "react-router-dom";
+import { motion } from "motion/react";
+import {
+  Search,
+  Zap,
+  Quote,
+  LayoutGrid,
+  FileUp,
+  ShieldCheck,
+} from "lucide-react";
+import { HeroSection } from "../components/hero/HeroSection";
+
+const features = [
+  {
+    icon: Search,
+    title: "Hybrid RAG Search",
+    desc: "BM25 keyword + vector similarity + AI re-ranking. Finds exactly what you need.",
+  },
+  {
+    icon: Zap,
+    title: "Real-time Streaming",
+    desc: "Answers stream in live via SSE. No waiting for full responses \u2014 see results instantly.",
+  },
+  {
+    icon: Quote,
+    title: "Source Citations",
+    desc: "Every answer cites its sources with confidence scores. Trust but verify.",
+  },
+  {
+    icon: LayoutGrid,
+    title: "Notion Integration",
+    desc: "One-click OAuth connect. Pages, databases, and blocks auto-ingested and indexed.",
+  },
+  {
+    icon: FileUp,
+    title: "File Uploads",
+    desc: "Upload PDFs, text files, and markdown. Chunked and embedded alongside your Notion docs.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Workspace Isolation",
+    desc: "Multi-tenant by design. Your data stays yours \u2014 queries scoped to your workspaces only.",
+  },
+];
+
+const techStack = [
+  "Google Gemini",
+  "Notion API",
+  "ChromaDB",
+  "FastAPI",
+  "React",
+];
+
+const steps = [
+  {
+    num: 1,
+    title: "Connect Notion",
+    desc: "OAuth in one click. We auto-index your pages, databases, and blocks.",
+  },
+  {
+    num: 2,
+    title: "Ask a Question",
+    desc: "Type naturally. WorkMate searches across all your connected documents.",
+  },
+  {
+    num: 3,
+    title: "Get Sourced Answers",
+    desc: "Streamed responses with citations, confidence scores, and source links.",
+  },
+];
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 24 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-60px" },
+  transition: { duration: 0.5 },
+};
+
+export function LandingPage() {
+  return (
+    <>
+      <HeroSection />
+
+      <div className="mx-6 h-px bg-gradient-to-r from-transparent via-purple-500/20 to-transparent" />
+
+      <motion.section className="py-8 text-center" {...fadeInUp}>
+        <p className="mb-4 text-[11px] uppercase tracking-widest text-white/30">
+          Built with
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-8 text-xs text-white/25 md:gap-12">
+          {techStack.map((t) => (
+            <span key={t}>{t}</span>
+          ))}
+        </div>
+      </motion.section>
+
+      <div className="mx-6 h-px bg-gradient-to-r from-transparent via-white/5 to-transparent" />
+
+      <section className="px-6 py-16 md:py-24">
+        <motion.div className="mb-10 text-center" {...fadeInUp}>
+          <p className="mb-3 text-[10px] uppercase tracking-[3px] text-purple-500">
+            Features
+          </p>
+          <h2 className="text-xl font-bold text-white md:text-2xl">
+            Everything you need to unlock
+            <br />
+            your team&apos;s knowledge
+          </h2>
+        </motion.div>
+        <div className="mx-auto grid max-w-5xl gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((f, i) => (
+            <motion.div
+              key={f.title}
+              className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-6 transition-colors hover:border-white/[0.12]"
+              {...fadeInUp}
+              transition={{ duration: 0.5, delay: i * 0.08 }}
+            >
+              <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-lg border border-purple-600/20 bg-purple-600/[0.08]">
+                <f.icon className="h-5 w-5 text-purple-500" />
+              </div>
+              <h3 className="mb-1.5 text-sm font-semibold text-white">
+                {f.title}
+              </h3>
+              <p className="text-xs leading-relaxed text-white/40">{f.desc}</p>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+
+      <div className="mx-6 h-px bg-gradient-to-r from-transparent via-white/5 to-transparent" />
+
+      <section id="how-it-works" className="px-6 py-16 md:py-24">
+        <motion.div className="mb-10 text-center" {...fadeInUp}>
+          <p className="mb-3 text-[10px] uppercase tracking-[3px] text-purple-500">
+            How It Works
+          </p>
+          <h2 className="text-xl font-bold text-white md:text-2xl">
+            Three steps to instant answers
+          </h2>
+        </motion.div>
+        <div className="mx-auto flex max-w-3xl flex-col items-start gap-8 md:flex-row md:items-center md:gap-6">
+          {steps.map((s, i) => (
+            <motion.div
+              key={s.num}
+              className="flex flex-1 flex-col items-center text-center"
+              {...fadeInUp}
+              transition={{ duration: 0.5, delay: i * 0.15 }}
+            >
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-purple-600/30 bg-purple-600/10 text-lg font-bold text-purple-500">
+                {s.num}
+              </div>
+              <h3 className="mb-1 text-sm font-semibold text-white">
+                {s.title}
+              </h3>
+              <p className="text-xs leading-relaxed text-white/40">{s.desc}</p>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+
+      <div className="mx-6 h-px bg-gradient-to-r from-transparent via-white/5 to-transparent" />
+
+      <motion.section
+        className="relative px-6 py-16 text-center md:py-24"
+        {...fadeInUp}
+      >
+        <div className="pointer-events-none absolute left-1/2 top-1/2 h-[200px] w-[400px] -translate-x-1/2 -translate-y-1/2 bg-[radial-gradient(ellipse,rgba(124,58,237,0.06)_0%,transparent_70%)]" />
+        <div className="relative z-10">
+          <h2 className="text-2xl font-bold text-white">
+            Ready to try WorkMate?
+          </h2>
+          <p className="mt-3 text-sm text-white/40">
+            Connect your Notion workspace and start getting answers in minutes.
+          </p>
+          <Link
+            to="/login"
+            className="mt-6 inline-block rounded-lg bg-purple-600 px-8 py-3 text-sm font-medium text-white transition-colors hover:bg-purple-700"
+          >
+            Get Started Free
+          </Link>
+        </div>
+      </motion.section>
+    </>
+  );
+}

--- a/frontend/src/public/pages/PricingPage.tsx
+++ b/frontend/src/public/pages/PricingPage.tsx
@@ -1,0 +1,180 @@
+import { Link } from "react-router-dom";
+import { motion } from "motion/react";
+import { Check } from "lucide-react";
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 24 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-60px" },
+  transition: { duration: 0.5 },
+};
+
+interface Tier {
+  name: string;
+  price: string;
+  unit: string;
+  description: string;
+  features: string[];
+  cta: string;
+  highlighted: boolean;
+}
+
+const tiers: Tier[] = [
+  {
+    name: "Free",
+    price: "$0",
+    unit: "/month",
+    description: "For individuals exploring WorkMate",
+    features: [
+      "1 Notion workspace",
+      "50 questions / month",
+      "5 file uploads",
+      "Source citations",
+      "Real-time streaming",
+      "Community support",
+    ],
+    cta: "Get Started Free",
+    highlighted: false,
+  },
+  {
+    name: "Pro",
+    price: "$12",
+    unit: "/user/month",
+    description: "For teams who need full access",
+    features: [
+      "Unlimited workspaces",
+      "Unlimited questions",
+      "Unlimited file uploads",
+      "Priority support",
+      "Advanced analytics",
+      "Conversation export",
+    ],
+    cta: "Get Started",
+    highlighted: true,
+  },
+  {
+    name: "Enterprise",
+    price: "Custom",
+    unit: "",
+    description: "For organizations with advanced needs",
+    features: [
+      "Everything in Pro",
+      "SSO / SAML",
+      "Custom integrations",
+      "Dedicated support",
+      "SLA guarantee",
+      "On-premise deployment",
+    ],
+    cta: "Contact Us",
+    highlighted: false,
+  },
+];
+
+export function PricingPage() {
+  return (
+    <>
+      <section className="relative px-6 pb-8 pt-20 text-center md:pt-28">
+        <div className="pointer-events-none absolute left-1/2 top-1/2 h-[300px] w-[500px] -translate-x-1/2 -translate-y-1/2 bg-[radial-gradient(ellipse,rgba(124,58,237,0.05)_0%,transparent_70%)]" />
+        <div className="relative z-10">
+          <p className="mb-4 text-[10px] uppercase tracking-[3px] text-purple-500">
+            Pricing
+          </p>
+          <h1 className="text-2xl font-bold text-white md:text-3xl">
+            Simple, transparent pricing
+          </h1>
+          <p className="mt-3 text-sm text-white/40">
+            Start free. Upgrade as your team grows.
+          </p>
+        </div>
+      </section>
+
+      <section className="px-6 pb-16">
+        <div className="mx-auto grid max-w-4xl items-stretch gap-4 lg:grid-cols-3">
+          {tiers.map((tier, i) => (
+            <motion.div
+              key={tier.name}
+              className={`relative flex flex-col rounded-xl border p-8 ${
+                tier.highlighted
+                  ? "border-purple-600/30 bg-purple-600/[0.05]"
+                  : "border-white/[0.06] bg-white/[0.02]"
+              }`}
+              {...fadeInUp}
+              transition={{ duration: 0.5, delay: i * 0.1 }}
+            >
+              {tier.highlighted && (
+                <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-purple-600 px-4 py-1 text-[10px] font-semibold uppercase tracking-widest text-white">
+                  Popular
+                </span>
+              )}
+
+              <div>
+                <p className="text-xs uppercase tracking-widest text-white/40">
+                  {tier.name}
+                </p>
+                <div className="mt-2 flex items-baseline gap-1">
+                  <span className="text-4xl font-bold text-white">
+                    {tier.price}
+                  </span>
+                  {tier.unit && (
+                    <span className="text-sm text-white/30">{tier.unit}</span>
+                  )}
+                </div>
+                <p className="mt-2 text-xs text-white/35">{tier.description}</p>
+              </div>
+
+              <div
+                className={`mt-6 flex-1 border-t pt-6 ${
+                  tier.highlighted
+                    ? "border-purple-600/15"
+                    : "border-white/[0.06]"
+                }`}
+              >
+                <ul className="space-y-3">
+                  {tier.features.map((f) => (
+                    <li
+                      key={f}
+                      className="flex items-center gap-2 text-xs text-white/50"
+                    >
+                      <Check className="h-3.5 w-3.5 shrink-0 text-emerald-500" />
+                      {f}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="mt-8">
+                {tier.name === "Enterprise" ? (
+                  <Link
+                    to="/contact"
+                    className="block rounded-lg border border-white/[0.08] bg-white/[0.04] py-2.5 text-center text-sm text-white/60 transition-colors hover:border-white/[0.15]"
+                  >
+                    {tier.cta}
+                  </Link>
+                ) : (
+                  <Link
+                    to="/login"
+                    className={`block rounded-lg py-2.5 text-center text-sm font-medium transition-colors ${
+                      tier.highlighted
+                        ? "bg-purple-600 text-white hover:bg-purple-700"
+                        : "border border-white/[0.08] bg-white/[0.04] text-white/60 hover:border-white/[0.15]"
+                    }`}
+                  >
+                    {tier.cta}
+                  </Link>
+                )}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+
+        <p className="mt-10 text-center text-sm text-white/40">
+          Have questions? Check our{" "}
+          <Link to="/docs" className="text-purple-500 underline">
+            Docs &amp; FAQ
+          </Link>{" "}
+          page.
+        </p>
+      </section>
+    </>
+  );
+}

--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -102,7 +102,7 @@ async def google_callback(code: str, db: Session = Depends(get_db)):
     jwt_token = create_access_token({"sub": str(user.id)})
 
     # Redirect to frontend with token
-    redirect_url = f"{settings.FRONTEND_URL}?token={jwt_token}"
+    redirect_url = f"{settings.FRONTEND_URL}/app?token={jwt_token}"
     return RedirectResponse(url=redirect_url)
 
 

--- a/src/backend/routers/notion.py
+++ b/src/backend/routers/notion.py
@@ -201,7 +201,7 @@ async def notion_callback(
             _ingest_workspace, workspace.id, access_token, notion_workspace_id
         )
 
-    redirect_url = f"{settings.FRONTEND_URL}/settings?notion=connected"
+    redirect_url = f"{settings.FRONTEND_URL}/app/settings?notion=connected"
     return RedirectResponse(url=redirect_url)
 
 


### PR DESCRIPTION
## Summary
- Built a 6-page public marketing site (Landing, About, Pricing, Docs, Demo, Contact) with a shared PublicLayout (Navbar + Footer)
- Moved existing authenticated app routes from `/` to `/app/*` with all internal links and backend OAuth redirects updated
- Dark premium design with animated hero section (floating Notion doc blocks, live chat preview with blinking cursor), Lucide icons, Motion animations, and responsive layouts
- No new dependencies — uses existing Motion, Lucide React, shadcn/ui, and React Router

## Pages
| Route | Status |
|-------|--------|
| `/` | Landing — hero, features, how-it-works, CTA |
| `/about` | Team bios, mission, color-coded tech stack |
| `/pricing` | 3-tier cards (Free/Pro/Enterprise) |
| `/docs` | Getting started guide + FAQ accordion |
| `/demo` | Coming soon |
| `/contact` | Coming soon |
| `/app/*` | Existing authenticated app (re-routed) |

## Test plan
- [x] Visit each public route and verify rendering
- [x] Test navbar links, active states, and mobile hamburger menu
- [ ] Sign in via Google OAuth and verify redirect to `/app`
- [x] Verify sidebar links work at `/app`, `/app/settings`, `/app/admin`
- [ ] Test Notion OAuth callback redirects to `/app/settings`
- [x] Check responsive layouts at mobile/tablet/desktop widths
- [ ] Run `npm run build` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)