### PR TITLE
Deployment/containerize push to ecr

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,51 @@
+# ── Secrets ──────────────────────────────────────────────────────
+.env
+.env.*
+
+# ── Python runtime / venvs ───────────────────────────────────────
+.venv/
+venv/
+env/
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.Python
+
+# ── Databases (live on IBM LinuxONE, not in the image) ───────────
+workmate.db
+chroma_db/
+workmate_db/
+*.db
+*.sqlite3
+
+# ── Frontend (deployed on Cloudflare) ────────────────────────────
+frontend/
+
+# ── Dev / test artifacts ─────────────────────────────────────────
+tests/
+docs/
+*.log
+chunk_tuning_experiment.py
+ingest.py
+
+# ── Data directories ─────────────────────────────────────────────
+src/data/
+input/
+output/
+
+# ── Version control / IDE ────────────────────────────────────────
+.git/
+.gitignore
+.gitattributes
+.vscode/
+.idea/
+
+# ── OS ───────────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ── Antigravity / CI tooling ─────────────────────────────────────
+.agent/
+scripts/
+k8s/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# ─────────────────────────────────────────────────────────────────
+# Stage 1: Builder
+# Install uv and sync dependencies from the lockfile into a venv.
+# ─────────────────────────────────────────────────────────────────
+FROM --platform=linux/amd64 python:3.13-slim AS builder
+
+# Install uv (fast Python package manager used by this project)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# Copy dependency manifests first — maximises layer cache reuse
+# on subsequent builds where only application code changes.
+COPY pyproject.toml uv.lock ./
+
+# Sync locked dependencies into the project venv.
+# --frozen  → fail fast if lockfile is stale (enforces reproducibility)
+# --no-dev  → exclude dev/test extras from the production image
+# --no-cache → skip uv's HTTP cache; keeps the layer lean
+RUN uv sync --frozen --no-dev --no-cache
+
+# ─────────────────────────────────────────────────────────────────
+# Stage 2: Runtime
+# Lean final image — only the pre-built venv and application source.
+# ─────────────────────────────────────────────────────────────────
+FROM --platform=linux/amd64 python:3.13-slim AS runtime
+
+# Create a non-root user (defence-in-depth for container security)
+RUN groupadd --gid 1000 appuser && \
+    useradd  --uid 1000 --gid appuser --shell /bin/bash --create-home appuser
+
+WORKDIR /app
+
+# Copy the populated venv from the builder stage
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+
+# Copy application source (secrets + DBs are excluded via .dockerignore)
+COPY --chown=appuser:appuser main.py ./main.py
+COPY --chown=appuser:appuser src/    ./src/
+
+# Activate the venv by prepending it to PATH
+ENV PATH="/app/.venv/bin:$PATH" \
+    # Prevent Python from writing .pyc files inside the container
+    PYTHONDONTWRITEBYTECODE=1   \
+    # Ensure stdout/stderr are flushed immediately (important for logs)
+    PYTHONUNBUFFERED=1
+
+USER appuser
+
+EXPOSE 8000
+
+# Production: no --reload flag; scale via WEB_CONCURRENCY env var if needed
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -1,0 +1,34 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: workmate-cluster
+  region: us-east-1
+  version: "1.30"
+
+# IAM OIDC provider — required for AWS Load Balancer Controller and
+# any pods that need to assume IAM roles via IRSA (IAM Roles for
+# Service Accounts).
+iam:
+  withOIDC: true
+
+managedNodeGroups:
+  - name: ng-workmate
+    instanceType: t3.medium
+    # Start with 2 nodes; autoscaler can grow to 4 during traffic spikes.
+    desiredCapacity: 2
+    minSize: 1
+    maxSize: 4
+    # Spread nodes across AZs for high availability
+    availabilityZones:
+      - us-east-1a
+      - us-east-1b
+    # Grant nodes the ability to pull images from ECR
+    iam:
+      attachPolicyARNs:
+        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+    tags:
+      Project: WorkMate
+      Environment: production

--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -13,11 +13,12 @@ iam:
   withOIDC: true
 
 managedNodeGroups:
-  - name: ng-workmate-pd
+  - name: ng-workmate-pd-v2
     maxPodsPerNode: 11
     instanceType: t3.micro
-    # Start with 2 nodes; autoscaler can grow to 4 during traffic spikes.
-    desiredCapacity: 2
+    # Start with 1 nodes; autoscaler can grow to 4 during traffic spikes.
+    desiredCapacity: 1
+    volumeSize: 20
     minSize: 1
     maxSize: 4
     # Grant nodes the ability to pull images from ECR

--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -13,7 +13,8 @@ iam:
   withOIDC: true
 
 managedNodeGroups:
-  - name: ng-workmate
+  - name: ng-workmate-pd
+    maxPodsPerNode: 11
     instanceType: t3.micro
     # Start with 2 nodes; autoscaler can grow to 4 during traffic spikes.
     desiredCapacity: 2

--- a/k8s/cluster.yaml
+++ b/k8s/cluster.yaml
@@ -14,15 +14,11 @@ iam:
 
 managedNodeGroups:
   - name: ng-workmate
-    instanceType: t3.medium
+    instanceType: t3.micro
     # Start with 2 nodes; autoscaler can grow to 4 during traffic spikes.
     desiredCapacity: 2
     minSize: 1
     maxSize: 4
-    # Spread nodes across AZs for high availability
-    availabilityZones:
-      - us-east-1a
-      - us-east-1b
     # Grant nodes the ability to pull images from ECR
     iam:
       attachPolicyARNs:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -66,15 +66,15 @@ spec:
           # ── Resources ─────────────────────────────────────────
           resources:
             requests:
-              cpu: "250m"
-              memory: "512Mi"
+              cpu: "10m"
+              memory: "64Mi"
             limits:
               cpu: "500m"
-              memory: "1Gi"
+              memory: "256Mi"
           # ── Container security ────────────────────────────────
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false   # uvicorn needs /tmp write access
+            readOnlyRootFilesystem: false # uvicorn needs /tmp write access
             capabilities:
               drop:
                 - ALL

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: workmate-backend
           # Replace with the real ECR URI after pushing the image:
           # <AWS_ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/workmate-backend:latest
-          image: REPLACE_WITH_ECR_IMAGE_URI
+          image: 246710930255.dkr.ecr.us-east-1.amazonaws.com/workmate-backend:91bb313
           imagePullPolicy: Always
           ports:
             - name: http

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workmate-backend
+  namespace: workmate
+  labels:
+    app.kubernetes.io/name: workmate
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: workmate-backend
+  # Zero-downtime rolling update: bring up new pods before removing old
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: workmate-backend
+        app.kubernetes.io/name: workmate
+        app.kubernetes.io/component: backend
+    spec:
+      # ── Security context ───────────────────────────────────────
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: workmate-backend
+          # Replace with the real ECR URI after pushing the image:
+          # <AWS_ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/workmate-backend:latest
+          image: REPLACE_WITH_ECR_IMAGE_URI
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          # ── Environment ───────────────────────────────────────
+          envFrom:
+            - secretRef:
+                name: workmate-secrets
+          # ── Health probes ─────────────────────────────────────
+          # Liveness: restart the pod if /health stops responding
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          # Readiness: only route traffic once /health returns 200
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          # ── Resources ─────────────────────────────────────────
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"
+          # ── Container security ────────────────────────────────
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false   # uvicorn needs /tmp write access
+            capabilities:
+              drop:
+                - ALL
+      # ── Pod scheduling ────────────────────────────────────────
+      # Prefer spreading replicas across nodes for HA
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: workmate-backend

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workmate
+  labels:
+    app.kubernetes.io/name: workmate
+    app.kubernetes.io/managed-by: kubectl

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,51 @@
+# ─────────────────────────────────────────────────────────────────
+# WorkMate — Kubernetes Secret template
+#
+# ⚠️  DO NOT commit real credentials here.
+#     This file is a schema reference only. Apply real secrets with:
+#
+#   kubectl create secret generic workmate-secrets \
+#     --namespace workmate \
+#     --from-literal=DATABASE_URL="postgresql://user:pass@<ibm-host>:5432/workmate" \
+#     --from-literal=JWT_SECRET_KEY="<generated>" \
+#     ... (see all keys below)
+#
+#     Or use AWS Secrets Manager + the External Secrets Operator.
+# ─────────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Secret
+metadata:
+  name: workmate-secrets
+  namespace: workmate
+  labels:
+    app.kubernetes.io/name: workmate
+type: Opaque
+stringData:
+  # ── Database ──────────────────────────────────────────────────
+  # Points to IBM LinuxONE. Use PostgreSQL DSN format:
+  # postgresql://user:password@<ibm-linuxone-host>:<port>/workmate
+  DATABASE_URL: "REPLACE_ME"
+
+  # ── Auth ──────────────────────────────────────────────────────
+  GOOGLE_CLIENT_ID: "REPLACE_ME"
+  GOOGLE_CLIENT_SECRET: "REPLACE_ME"
+  # Production callback must match the OAuth app config in Google Cloud Console
+  GOOGLE_REDIRECT_URI: "https://api.REPLACE_ME.com/api/auth/google/callback"
+
+  JWT_SECRET_KEY: "REPLACE_ME"
+  JWT_ALGORITHM: "HS256"
+  JWT_EXPIRE_MINUTES: "1440"
+
+  # ── CORS — must match the Cloudflare frontend domain exactly ──
+  FRONTEND_URL: "https://REPLACE_ME.pages.dev"
+
+  # ── AI / LLM ──────────────────────────────────────────────────
+  GEMINI_API_KEY: "REPLACE_ME"
+  VOYAGE_API_KEY: "REPLACE_ME"
+
+  # ── Notion OAuth ──────────────────────────────────────────────
+  NOTION_TOKEN: "REPLACE_ME"
+  NOTION_OAUTH_CLIENT_ID: "REPLACE_ME"
+  NOTION_OAUTH_CLIENT_SECRET: "REPLACE_ME"
+  NOTION_REDIRECT_URI: "https://api.REPLACE_ME.com/api/notion/callback"
+  NOTION_ENCRYPTION_KEY: "REPLACE_ME"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: workmate-service
+  namespace: workmate
+  labels:
+    app.kubernetes.io/name: workmate
+    app.kubernetes.io/component: backend
+  annotations:
+    # AWS will provision a Classic/Network Load Balancer.
+    # Swap to "nlb" for a Network Load Balancer (recommended for HTTPS termination
+    # at the LB level); or add the AWS Load Balancer Controller for an ALB.
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    # Enable cross-zone load balancing so traffic is distributed evenly
+    # across pods in both AZs.
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+spec:
+  type: LoadBalancer
+  selector:
+    app: workmate-backend
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80          # external port clients (Cloudflare, browsers) call
+      targetPort: 8000  # forwarded to the container

--- a/scripts/docker-push-ecr.sh
+++ b/scripts/docker-push-ecr.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/docker-push-ecr.sh
+#
+# Build the WorkMate backend Docker image and push it to AWS ECR.
+#
+# Required env vars:
+#   AWS_ACCOUNT_ID   — your 12-digit AWS account ID
+#   AWS_REGION       — target region (default: us-east-1)
+#
+# Optional env vars:
+#   IMAGE_TAG        — tag to apply in addition to :latest (default: git SHA)
+#   ECR_REPO         — ECR repository name (default: workmate-backend)
+#
+# Usage:
+#   export AWS_ACCOUNT_ID=123456789012
+#   export AWS_REGION=us-east-1
+#   ./scripts/docker-push-ecr.sh
+# =============================================================================
+set -euo pipefail
+
+# ── Config ────────────────────────────────────────────────────────────────────
+AWS_REGION="${AWS_REGION:-us-east-1}"
+ECR_REPO="${ECR_REPO:-workmate-backend}"
+IMAGE_TAG="${IMAGE_TAG:-$(git rev-parse --short HEAD 2>/dev/null || echo "manual")}"
+
+if [[ -z "${AWS_ACCOUNT_ID:-}" ]]; then
+  echo "❌  AWS_ACCOUNT_ID is not set. Export it before running this script."
+  exit 1
+fi
+
+ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+FULL_IMAGE="${ECR_REGISTRY}/${ECR_REPO}"
+
+echo "════════════════════════════════════════════════════════"
+echo "  WorkMate ECR Push"
+echo "  Registry : ${ECR_REGISTRY}"
+echo "  Repo     : ${ECR_REPO}"
+echo "  Tags     : latest, ${IMAGE_TAG}"
+echo "════════════════════════════════════════════════════════"
+
+# ── Step 1: Authenticate Docker with ECR ─────────────────────────────────────
+echo ""
+echo "▶ Authenticating Docker with ECR…"
+aws ecr get-login-password --region "${AWS_REGION}" \
+  | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
+# ── Step 2: Create ECR repo if it doesn't already exist ──────────────────────
+echo ""
+echo "▶ Ensuring ECR repo '${ECR_REPO}' exists…"
+aws ecr describe-repositories \
+  --region "${AWS_REGION}" \
+  --repository-names "${ECR_REPO}" \
+  > /dev/null 2>&1 \
+|| aws ecr create-repository \
+  --region "${AWS_REGION}" \
+  --repository-name "${ECR_REPO}" \
+  --image-scanning-configuration scanOnPush=true \
+  --encryption-configuration encryptionType=AES256 \
+  > /dev/null
+
+# ── Step 3: Build image for linux/amd64 (EKS node arch) ──────────────────────
+echo ""
+echo "▶ Building image for linux/amd64…"
+docker buildx build \
+  --platform linux/amd64 \
+  --tag "${FULL_IMAGE}:latest" \
+  --tag "${FULL_IMAGE}:${IMAGE_TAG}" \
+  --file Dockerfile \
+  .
+
+# ── Step 4: Push both tags ────────────────────────────────────────────────────
+echo ""
+echo "▶ Pushing tags to ECR…"
+docker push "${FULL_IMAGE}:latest"
+docker push "${FULL_IMAGE}:${IMAGE_TAG}"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+echo ""
+echo "✅  Image pushed successfully."
+echo ""
+echo "  Full image URI (use this in k8s/deployment.yaml):"
+echo "  ${FULL_IMAGE}:${IMAGE_TAG}"
+echo ""
+echo "  Next steps:"
+echo "  1. Update k8s/deployment.yaml  →  image: ${FULL_IMAGE}:${IMAGE_TAG}"
+echo "  2. kubectl apply -f k8s/"

--- a/scripts/docker-push-ecr.sh
+++ b/scripts/docker-push-ecr.sh
@@ -19,6 +19,16 @@
 # =============================================================================
 set -euo pipefail
 
+# ── Resolve tool paths (works regardless of invocation context) ───────────────
+# Prefer Homebrew AWS CLI v2; fall back to pip-installed v1
+export PATH="/opt/homebrew/bin:/usr/local/bin:/Users/ruts/Library/Python/3.9/bin:${PATH:-}"
+
+# Docker CLI — Docker Desktop on macOS installs here
+DOCKER="${DOCKER:-/Applications/Docker.app/Contents/Resources/bin/docker}"
+if ! command -v docker &>/dev/null && [[ -x "$DOCKER" ]]; then
+  export PATH="$(dirname "$DOCKER"):$PATH"
+fi
+
 # ── Config ────────────────────────────────────────────────────────────────────
 AWS_REGION="${AWS_REGION:-us-east-1}"
 ECR_REPO="${ECR_REPO:-workmate-backend}"

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from src.backend.config import settings
 from src.backend.database import Base, engine
@@ -18,6 +19,14 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # ── Health check ─────────────────────────────────────────────
+    # Lightweight endpoint used by EKS liveness and readiness probes.
+    # Intentionally placed before router includes so it is always
+    # reachable even if downstream routers fail to load.
+    @app.get("/health", tags=["health"], include_in_schema=False)
+    async def health_check() -> JSONResponse:
+        return JSONResponse({"status": "ok"})
 
     app.include_router(auth.router)
     app.include_router(admin.router)


### PR DESCRIPTION
# Description

This PR introduces the foundational infrastructure and orchestration configurations necessary to containerize the WorkMate backend and deploy it to a production-ready AWS Elastic Kubernetes Service (EKS) cluster. 

It covers Docker construction, an automated ECR pushing mechanism, Kubernetes manifest generation, and EKS cluster definitions tailored for AWS Free Tier compliance (using `t3.micro` instances).

## Key Changes

### 🐳 Docker Configurations
- **Multi-stage `Dockerfile`**: Added a production-optimized multi-stage Dockerfile to build a nimble, secure image.
- **`.dockerignore`**: Created an ignore list to prevent sensitive keys, local virtual environments, and frontend artifacts from leaking into the build context.

### 📜 ECR Pipeline Script
- **`scripts/docker-push-ecr.sh`**: Introduced a shell script to automate Docker authentication, image building using exact architecture targets (`linux/amd64`), and pushing tagged images to the AWS ECR registry.

### ☸️ Kubernetes & EKS Infrastructure
- **Manifests generation**: Added the necessary Kubernetes resources including `Deployment`, `Service` (Network Load Balancer), and `Namespace` manifests.
- **Eksctl configuration**: Added `eks-cluster.yaml` to declaratively specify the cluster properties.
- **VPC CNI & Free-Tier Adjustments**: 
  - Renamed the node group to `ng-workmate-pd`.
  - Configured `maxPodsPerNode` to `11` to facilitate VPC CNI prefix delegation.
  - Locked the node type to `t3.micro` to securely fit within the AWS Free Tier limitations.

### 🏥 App Health Monitoring
- **Health-check Endpoint**: Implemented a lightweight `GET /health` endpoint in the FastAPI backend (`src/backend/app.py`) to serve as a reliable target for Kubernetes Liveness and Readiness probes.

## Commits in this PR

* `59484da` chore: rename managed node group to ng-workmate-pd and set maxPodsPerNode to 11
* `822e71b` chore: downgrade node instance type to t3.micro and remove explicit availability zone configuration
* `434be73` chore(deploy): set ECR image URI and fix tool PATH in push script
* `91bb313` feat(scripts): add docker-push-ecr.sh to build and push image to ECR
* `6a47b51` feat(k8s): add Kubernetes manifests and eksctl cluster config
* `c9e7d15` feat(docker): add multi-stage Dockerfile for production EKS deployment
* `afe39a0` chore: add .dockerignore to exclude secrets, DBs, venv, and frontend from build context
* `3900a31` feat: add GET /health endpoint for EKS liveness and readiness probes

## DevOps & Testing Notes
- **Liveness/Readiness**: EKS will verify pod health against the new `/health` endpoint.
- **Build Arch**: Ensure local builds invoke `linux/amd64` architecture (done explicitly in the sh script) as the target remote instances are x86/amd64-based.
